### PR TITLE
fix some relative path issues

### DIFF
--- a/branch/src/main/scala/dev/wishingtree/branch/macaroni/fs/PathOps.scala
+++ b/branch/src/main/scala/dev/wishingtree/branch/macaroni/fs/PathOps.scala
@@ -1,7 +1,6 @@
 package dev.wishingtree.branch.macaroni.fs
 
 import java.nio.file.*
-import scala.jdk.CollectionConverters.*
 
 object PathOps {
 
@@ -18,13 +17,17 @@ object PathOps {
     /** Append a Path to the path */
     def /(subPath: Path): Path = path.resolve(subPath)
 
-    /** Convert the path to a String. It will be prefixed with a slash
-      */
-    def toPathString = "/" + path.toString
-
     /** Convert the path to a Seq[String]
       */
     def toSeq: Seq[String] = path.toString.split("/").filter(_.nonEmpty).toSeq
+
+    /** Relativize the path to the given rootPath. */
+    def relativeTo(rootPath: String): Path =
+      Path.of(rootPath).relativize(path)
+
+    /** Relativize the path to the given rootPath. */
+    def relativeTo(rootPath: Path): Path =
+      rootPath.relativize(path)
   }
 
   object / {

--- a/branch/src/main/scala/dev/wishingtree/branch/spider/server/ContextHandler.scala
+++ b/branch/src/main/scala/dev/wishingtree/branch/spider/server/ContextHandler.scala
@@ -4,7 +4,7 @@ import com.sun.net.httpserver.*
 import dev.wishingtree.branch.lzy.Lazy
 import dev.wishingtree.branch.lzy.abstractions.Semigroup
 import dev.wishingtree.branch.spider.HttpMethod
-
+import dev.wishingtree.branch.macaroni.fs.PathOps.*
 import java.time.{Duration, Instant}
 import java.nio.file.Path
 import scala.jdk.CollectionConverters.*
@@ -37,7 +37,7 @@ trait ContextHandler(val path: String) {
           .fn {
             HttpMethod
               .fromString(exchange.getRequestMethod.toUpperCase)
-              .map(v => v -> Path.of(exchange.getRequestURI.getPath))
+              .map(v => v -> Path.of(exchange.getRequestURI.getPath).relativeTo("/"))
               .filter(contextRouter.isDefinedAt)
               .map(contextRouter)
               .getOrElse(RequestHandler.unimplementedHandler)

--- a/branch/src/main/scala/dev/wishingtree/branch/spider/server/FileContextHandler.scala
+++ b/branch/src/main/scala/dev/wishingtree/branch/spider/server/FileContextHandler.scala
@@ -27,7 +27,7 @@ case class FileContextHandler(
 ) extends ContextHandler(contextPath) {
 
   private def fileExists(path: Path): Boolean = {
-    val filePath = (rootFilePath / path).toPathString
+    val filePath = (rootFilePath / path).toString
     val file     = new File(filePath)
     file.exists() && file.isFile
   }
@@ -35,14 +35,14 @@ case class FileContextHandler(
   private def defaultExists(path: Path): Boolean = {
     !path.toSeq.lastOption.exists(_.contains("\\.")) &&
     FileContextHandler.defaultFiles.foldLeft(false) { (b, d) =>
-      val file = new File((rootFilePath / path / d).toPathString)
+      val file = new File((rootFilePath / path / d).toString)
       b || (file.exists() && file.isFile)
     }
   }
 
   private def defaultFile(path: Path): File =
     FileContextHandler.defaultFiles.iterator
-      .map(fn => new File((rootFilePath / path / fn).toPathString))
+      .map(fn => new File((rootFilePath / path / fn).toString))
       .find(_.exists())
       .getOrElse(throw new Exception("Not found"))
 

--- a/branch/src/main/scala/dev/wishingtree/branch/spider/server/FileHandler.scala
+++ b/branch/src/main/scala/dev/wishingtree/branch/spider/server/FileHandler.scala
@@ -1,9 +1,8 @@
 package dev.wishingtree.branch.spider.server
 
+import dev.wishingtree.branch.macaroni.fs.PathOps.*
 import dev.wishingtree.branch.spider.server.FileHandler.given
 import dev.wishingtree.branch.spider.server.RequestHandler.given
-import dev.wishingtree.branch.spider.server.{Request, RequestHandler, Response}
-import dev.wishingtree.branch.macaroni.fs.PathOps.*
 
 import java.io.{File, FileInputStream, FileNotFoundException}
 import java.nio.file.Path
@@ -32,7 +31,7 @@ private[spider] case class FileHandler(rootFilePath: Path)
     extends RequestHandler[Unit, File] {
 
   override def handle(request: Request[Unit]): Response[File] = {
-    val filePath = (rootFilePath / request.uri.getPath.toLowerCase).toPathString
+    val filePath = (rootFilePath / request.uri.getPath.stripPrefix("/")).toString
     Response(
       body = new File(filePath)
     ).autoContent(filePath)


### PR DESCRIPTION
When switching from OpaqueSeqments (Seq[String]) to using Path, there were some unexpected issues with the built in FileContextHandler, largely do to a preceding `/` in the matching (causing in to be an absolute path).

This PR
- relativizes the path being passed to the contextRouter
- removes toPathString method 
- address the same issue in FileHandler when loading File