### PR TITLE
Swap Lazy for Try in spider

### DIFF
--- a/branch/src/main/scala/dev/wishingtree/branch/spider/server/SpiderApp.scala
+++ b/branch/src/main/scala/dev/wishingtree/branch/spider/server/SpiderApp.scala
@@ -1,7 +1,7 @@
 package dev.wishingtree.branch.spider.server
 
-import com.sun.net.httpserver.{HttpHandler, HttpServer}
-import dev.wishingtree.branch.lzy.LazyRuntime
+import com.sun.net.httpserver.HttpServer
+import dev.wishingtree.branch.macaroni.runtimes.BranchExecutors
 
 import java.net.InetSocketAddress
 
@@ -22,7 +22,7 @@ trait SpiderApp {
   final given server: HttpServer =
     HttpServer.create(new InetSocketAddress(port), backlog)
 
-  server.setExecutor(LazyRuntime.executorService)
+  server.setExecutor(BranchExecutors.executorService)
 
   Runtime.getRuntime.addShutdownHook {
     new Thread(() => server.stop(5))


### PR DESCRIPTION
When deploying an app on fly.io, I noticed what seemed like a deadlock when deploying on 1 cpu machine. No issue when scaling to 2 cpu. Not sure if it's related, but Lazy can/will use a lot of virtual threads, so swap those parts of spider out for plain Trys to see if it helps.