### PR TITLE
Lzy Future

### DIFF
--- a/branch/src/main/scala/dev/wishingtree/branch/lzy/Lazy.scala
+++ b/branch/src/main/scala/dev/wishingtree/branch/lzy/Lazy.scala
@@ -7,7 +7,7 @@ import java.util
 import java.util.logging.{Level, Logger}
 import scala.annotation.targetName
 import scala.collection.mutable
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.Duration
 import scala.reflect.ClassTag
 import scala.util.Try
@@ -153,12 +153,14 @@ object Lazy {
   extension [A](lzy: Lazy[A]) {
 
     /** Run the Lazy value synchronously */
-    def runSync(): Try[A] =
-      LazyRuntime.runSync(lzy)(using BranchExecutors.executionContext)
+    def runSync(d: Duration = Duration.Inf)(using
+        executionContext: ExecutionContext
+    ): Try[A] =
+      LazyRuntime.runSync(lzy, d)
 
     /** Run the Lazy value asynchronously */
-    def runAsync(): Future[A] =
-      LazyRuntime.runAsync(lzy)(using BranchExecutors.executionContext)
+    def runAsync(using executionContext: ExecutionContext): Future[A] =
+      LazyRuntime.runAsync(lzy)
   }
 
   private[lzy] final case class Fn[A](a: () => A)     extends Lazy[A]

--- a/branch/src/main/scala/dev/wishingtree/branch/lzy/Lazy.scala
+++ b/branch/src/main/scala/dev/wishingtree/branch/lzy/Lazy.scala
@@ -154,7 +154,7 @@ object Lazy {
 
     /** Run the Lazy value synchronously */
     def runSync(): Try[A] =
-      LazyRuntime.runSync(lzy)()(using BranchExecutors.executionContext)
+      LazyRuntime.runSync(lzy)(using BranchExecutors.executionContext)
 
     /** Run the Lazy value asynchronously */
     def runAsync(): Future[A] =
@@ -163,8 +163,6 @@ object Lazy {
 
   private[lzy] final case class Fn[A](a: () => A)     extends Lazy[A]
   private[lzy] final case class Fail[A](e: Throwable) extends Lazy[A]
-  private[lzy] final case class Suspend[A](resume: () => Lazy[A])
-      extends Lazy[A]
   private[lzy] final case class FlatMap[A, B](lzy: Lazy[A], f: A => Lazy[B])
       extends Lazy[B]
   private[lzy] final case class Recover[A](
@@ -196,7 +194,6 @@ object Lazy {
       xs: Iterator[A]
   )(xb: mutable.Builder[B, F[B]])(fn: A => Lazy[B]): Lazy[F[B]] = {
     xs.foldLeft(Lazy.fn(xb))((acc, curr) => {
-//      acc.flatMap(b => Lazy.Suspend(() => fn(curr).map(b.addOne)))
       acc.flatMap(b => fn(curr).map(b.addOne))
     }).as(xb.result())
   }

--- a/branch/src/main/scala/dev/wishingtree/branch/lzy/Lazy.test.scala
+++ b/branch/src/main/scala/dev/wishingtree/branch/lzy/Lazy.test.scala
@@ -1,14 +1,18 @@
 import dev.wishingtree.branch.lzy.{Lazy, LazyRuntime}
+import dev.wishingtree.branch.macaroni.runtimes.BranchExecutors
 import dev.wishingtree.branch.testkit.fixtures.LoggerFixtureSuite
 import munit.FunSuite
 
 import java.time.*
 import java.util.logging.Logger
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.DurationInt
 import scala.language.postfixOps
 import scala.util.Try
 
 class LazySpec extends LoggerFixtureSuite {
+
+  given ExecutionContext = BranchExecutors.executionContext
 
   override def munitValueTransforms = super.munitValueTransforms ++ List(
     new ValueTransform(
@@ -87,14 +91,14 @@ class LazySpec extends LoggerFixtureSuite {
 
   test("Lazy.iterate") {
     for {
-      l     <- Lazy.iterate((1 to 10000).iterator)(List.newBuilder[Int])(_ =>
+      l     <- Lazy.iterate((1 to 1000000).iterator)(List.newBuilder[Int])(_ =>
                  Lazy.fn(1)
                )
       empty <-
         Lazy.iterate(Iterator.empty)(List.newBuilder[Int])(_ => Lazy.fn(1))
     } yield {
-      assertEquals(l.size, 10000)
-      assertEquals(l.sum, 10000)
+      assertEquals(l.size, 1000000)
+      assertEquals(l.sum, 1000000)
       assertEquals(empty.size, 0)
     }
   }

--- a/branch/src/main/scala/dev/wishingtree/branch/lzy/LazyApp.scala
+++ b/branch/src/main/scala/dev/wishingtree/branch/lzy/LazyApp.scala
@@ -8,7 +8,11 @@ import scala.concurrent.ExecutionContext
   */
 trait LazyApp {
 
-  given ec: ExecutionContext = BranchExecutors.executionContext
+  /** The execution context used for the LazyRuntime, Defaults to
+    * BranchExecutors.executionContext (Virtual Thread per Task)
+    */
+  val executionContext: ExecutionContext =
+    BranchExecutors.executionContext
 
   /** The main Lazy chain to run the application.
     */
@@ -17,5 +21,5 @@ trait LazyApp {
   /** The main method to run the application.
     */
   final def main(args: Array[String]): Unit =
-    LazyRuntime.runSync(run)()
+    LazyRuntime.runSync(run)(using executionContext)
 }

--- a/branch/src/main/scala/dev/wishingtree/branch/lzy/LazyApp.scala
+++ b/branch/src/main/scala/dev/wishingtree/branch/lzy/LazyApp.scala
@@ -1,8 +1,14 @@
 package dev.wishingtree.branch.lzy
 
+import dev.wishingtree.branch.macaroni.runtimes.BranchExecutors
+
+import scala.concurrent.ExecutionContext
+
 /** A trait for creating a lazy application with a default main method.
   */
 trait LazyApp {
+
+  given ec: ExecutionContext = BranchExecutors.executionContext
 
   /** The main Lazy chain to run the application.
     */
@@ -11,5 +17,5 @@ trait LazyApp {
   /** The main method to run the application.
     */
   final def main(args: Array[String]): Unit =
-    LazyRuntime.runSync(run)
+    LazyRuntime.runSync(run)()
 }

--- a/branch/src/main/scala/dev/wishingtree/branch/lzy/LazyRuntime.scala
+++ b/branch/src/main/scala/dev/wishingtree/branch/lzy/LazyRuntime.scala
@@ -7,7 +7,7 @@ import scala.jdk.FutureConverters.*
 import scala.util.Try
 
 private[lzy] trait LazyRuntime {
-  def runSync[A](lzy: Lazy[A])(d: Duration)(using
+  def runSync[A](lzy: Lazy[A], d: Duration)(using
       executionContext: ExecutionContext
   ): Try[A]
   def runAsync[A](lzy: Lazy[A])(using
@@ -19,11 +19,11 @@ object LazyRuntime extends LazyRuntime {
 
   /** Run a Lazy value synchronously.
     */
-  override final def runSync[A](lzy: Lazy[A])(d: Duration = Duration.Inf)(using
+  override final def runSync[A](lzy: Lazy[A], d: Duration = Duration.Inf)(using
       executionContext: ExecutionContext
   ): Try[A] =
     Try(
-      Await.result(evalF(lzy), d)
+      Await.result(eval(lzy), d)
     )
 
   /** Run a Lazy value asynchronously.
@@ -31,53 +31,51 @@ object LazyRuntime extends LazyRuntime {
   override final def runAsync[A](lzy: Lazy[A])(using
       executionContext: ExecutionContext
   ): Future[A] =
-    evalF(lzy)
+    eval(lzy)
 
   @tailrec
-  private final def evalF[A](
+  private final def eval[A](
       lzy: Lazy[A]
   )(using executionContext: ExecutionContext): Future[A] = {
     lzy match {
       case Lazy.Fn(a)           => Future(a())
-      case Lazy.Suspend(s)      => evalF(s())
       case Lazy.FlatMap(lzy, f) =>
         lzy match {
-          case Lazy.Suspend(s)    => evalF(Lazy.FlatMap(s(), f))
-          case Lazy.FlatMap(l, g) => evalF(l.flatMap(g(_).flatMap(f)))
-          case Lazy.Fn(a)         => evalF(f(a()))
+          case Lazy.FlatMap(l, g) => eval(l.flatMap(g(_).flatMap(f)))
+          case Lazy.Fn(a)         => eval(f(a()))
           case Lazy.Fail(e)       => Future.failed(e)
-          case Lazy.Recover(l, r) => evalFFlatMapRecover(l, r, f)
-          case Lazy.Sleep(d)      => evalFFlatMapSleep(d, f)
+          case Lazy.Recover(l, r) => evalFlatMapRecover(l, r, f)
+          case Lazy.Sleep(d)      => evalFlatMapSleep(d, f)
         }
       case Lazy.Fail(e)         => Future.failed(e)
-      case Lazy.Recover(lzy, f) => evalFRecover(lzy, f)
+      case Lazy.Recover(lzy, f) => evalRecover(lzy, f)
       case Lazy.Sleep(d)        => Future(Thread.sleep(d.toMillis))
     }
   }
 
-  private final def evalFFlatMapSleep[A](d: Duration, f: Unit => Lazy[A])(using
+  private final def evalFlatMapSleep[A](d: Duration, f: Unit => Lazy[A])(using
       executionContext: ExecutionContext
   ): Future[A] = {
     Future {
       Thread.sleep(d.toMillis)
-    }.flatMap(_ => evalF(f(())))
+    }.flatMap(_ => eval(f(())))
   }
 
-  private final def evalFFlatMapRecover[A, B](
+  private final def evalFlatMapRecover[A, B](
       lzy: Lazy[A],
       r: Throwable => Lazy[A],
       f: A => Lazy[B]
   )(using executionContext: ExecutionContext): Future[B] = {
-    evalFRecover(lzy, r).flatMap(z => evalF(f(z)))
+    evalRecover(lzy, r).flatMap(z => eval(f(z)))
   }
 
-  private final def evalFRecover[A](
+  private final def evalRecover[A](
       lzy: Lazy[A],
       f: Throwable => Lazy[A]
   )(using executionContext: ExecutionContext): Future[A] = {
     lzy match {
-      case Lazy.Fail(e) => evalF(f(e))
-      case _            => evalF(lzy).recoverWith { case t: Throwable => evalF(f(t)) }
+      case Lazy.Fail(e) => eval(f(e))
+      case _            => eval(lzy).recoverWith { case t: Throwable => eval(f(t)) }
     }
   }
 }

--- a/branch/src/main/scala/dev/wishingtree/branch/lzy/LazyRuntime.test.scala
+++ b/branch/src/main/scala/dev/wishingtree/branch/lzy/LazyRuntime.test.scala
@@ -1,0 +1,57 @@
+package dev.wishingtree.branch.lzy
+
+import dev.wishingtree.branch.macaroni.runtimes.BranchExecutors
+import munit.FunSuite
+
+import scala.util.*
+import scala.concurrent.{ExecutionContext, TimeoutException}
+import scala.concurrent.duration.*
+import scala.language.postfixOps
+
+class LazyRuntimeSpec extends FunSuite {
+  given ExecutionContext = BranchExecutors.executionContext
+
+  test("LazyRuntime.runSync() captures the Future failure in the Try") {
+    val lazyFail = Lazy.fail(new ArithmeticException("bad math"))
+    assert(
+      LazyRuntime.runSync(lazyFail) match {
+        case Failure(e: ArithmeticException) => true
+        case _                               => false
+      }
+    )
+    val lazyBoom = Lazy.fn(throw new ArithmeticException("bad math"))
+    assert(
+      LazyRuntime.runSync(lazyBoom) match {
+        case Failure(e: ArithmeticException) => true
+        case _                               => false
+      }
+    )
+  }
+
+  test(
+    "LazyRuntime.runSync() times out when appropriate"
+  ) {
+    assert(
+      LazyRuntime.runSync(
+        Lazy.sleep(5 milliseconds),
+        1 milliseconds
+      ) match {
+        case Failure(e: TimeoutException) => true
+        case _                            => false
+      }
+    )
+  }
+
+  test(
+    "LazyRuntime.runSync() doesn't times out when appropriate"
+  ) {
+    assert(
+      LazyRuntime
+        .runSync(
+          Lazy.sleep(5 milliseconds),
+          10 milliseconds
+        )
+        .isSuccess
+    )
+  }
+}

--- a/branch/src/main/scala/dev/wishingtree/branch/testkit/fixtures/HttpFixtureSuite.test.scala
+++ b/branch/src/main/scala/dev/wishingtree/branch/testkit/fixtures/HttpFixtureSuite.test.scala
@@ -2,7 +2,7 @@
 package dev.wishingtree.branch.testkit.fixtures
 
 import com.sun.net.httpserver.HttpServer
-import dev.wishingtree.branch.lzy.LazyRuntime
+import dev.wishingtree.branch.macaroni.runtimes.BranchExecutors
 import dev.wishingtree.branch.spider.HttpMethod
 import dev.wishingtree.branch.spider.server.{ContextHandler, RequestHandler}
 import munit.FunSuite
@@ -19,7 +19,7 @@ trait HttpFixtureSuite extends FunSuite {
       setup = { test =>
         val port: Int = scala.util.Random.between(10000, 11000)
         val server    = HttpServer.create(new InetSocketAddress(port), 0)
-        server.setExecutor(LazyRuntime.executorService)
+        server.setExecutor(BranchExecutors.executorService)
         server.start()
         ContextHandler.registerHandler(new ContextHandler("/") {
           override val contextRouter: PF = routes

--- a/branch/src/main/scala/dev/wishingtree/branch/ursula/command/Command.test.scala
+++ b/branch/src/main/scala/dev/wishingtree/branch/ursula/command/Command.test.scala
@@ -1,8 +1,11 @@
 package dev.wishingtree.branch.ursula.command
 
+import dev.wishingtree.branch.macaroni.runtimes.BranchExecutors
 import dev.wishingtree.branch.ursula.args.*
 import dev.wishingtree.branch.ursula.extensions.Extensions.splitSeq
 import munit.*
+
+import scala.concurrent.ExecutionContext
 
 // A <-> B Conflict
 // C requires an argument
@@ -60,6 +63,7 @@ object NonStrictTestCommand extends TestCommand {
 }
 
 class CommandSpec extends FunSuite {
+  given ExecutionContext = BranchExecutors.executionContext
 
   val goodCommand: Seq[String] = "-a -d -c 123".splitSeq()
   val missingFlag: Seq[String] = "-c 123".splitSeq()


### PR DESCRIPTION
Make the LazyRuntime Future based. 

Evaluation is now tail recursive :tada:

This change also makes it possible to swap out the ExecutionContext, in cases where you don't want VirtualThreadPerTask.